### PR TITLE
change localhost ip to service name in docker file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ INSTANCE_MAX_RETRY_QR=2
 # DATABASE CONFIGURATION
 # ==================================
 MONGODB_ENABLED=false
-MONGODB_URL=mongodb://127.0.0.1:27017/whatsapp_api
+MONGODB_URL=mongodb://mongodb:27017/whatsapp_api
 
 # ==================================
 # WEBHOOK CONFIGURATION


### PR DESCRIPTION
for mongo URI you must use your MongoDB service name instead 127.0.0.1 or localhost

for example, in below docker-compose file my mongo service name is mongodb and I change URI like this mongodb://mongodb:27017/whatsapp_api and it works for me

I was getting the error:

"err":{"type":"TypeError","message":"Invalid URL","stack":"TypeError [ERR_INVALID_URL]: Invalid URL\n .... /home/node/app/node_modules/mongoose/lib/connection.js:813:36","input":"127.0.0.1:27017","code":"ERR_INVALID_URL"},"msg":"Invalid URL"

and now everything is ok